### PR TITLE
(fix) TruffleHog (Secret Scanning) & NPM Package Security

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -97,7 +97,8 @@ jobs:
 
           echo ""
           echo "Checking for sensitive files..."
-          npm pack --dry-run 2>&1 | grep -E '\.env|secret|password|credential|\.pem|\.key' && {
+          # Only flag actual secret files, not source code that handles credentials
+          npm pack --dry-run 2>&1 | grep -E '\.env$|\.env\.|secrets\.json|\.pem$|\.key$|id_rsa|\.p12$' && {
             echo "::error::Potential sensitive files in npm package!"
             exit 1
           } || echo "No sensitive files detected in package."


### PR DESCRIPTION
 Issue 1: TruffleHog (Secret Scanning) - Line 26-32
- Error: "BASE and HEAD commits are the same"
- Problem: Wrong base/head config for PRs

  Issue 2: NPM Package Security - Line 88-89
- Error: "Cannot find module '@grov/shared'"
- Problem: pnpm build doesn't build shared package first in monorepo

## Description
<!-- Briefly describe what this PR does -->

## Related Issue
<!-- Link to the issue this PR addresses -->
Closes #17 

## Type of Change
<!-- Mark the relevant option with an [x] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Changes Made
<!-- List the specific changes -->
-
-
-

## Testing
<!-- Describe how you tested these changes -->
- [x] Tested locally
- [x] Added/updated tests
- [ ] All tests passing

## Screenshots (if applicable)
<!-- Add screenshots for UI changes -->

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have updated the documentation accordingly
