### PR TITLE
 perf(dashboard): reduce LCP from 5-6s to ~1.7s with single RPC call

### DIFF
--- a/dashboard/next-env.d.ts
+++ b/dashboard/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/dashboard/src/lib/queries/dashboard-rpc.ts
+++ b/dashboard/src/lib/queries/dashboard-rpc.ts
@@ -1,0 +1,74 @@
+import { createClient } from '@/lib/supabase/server';
+
+/**
+ * Dashboard data returned by get_dashboard_data_v2 RPC
+ * Single query replaces 12+ individual queries
+ */
+export interface DashboardRpcResponse {
+  user: {
+    id: string;
+    email: string;
+    full_name: string | null;
+    avatar_url: string | null;
+    created_at: string;
+  } | null;
+  teams: Array<{
+    id: string;
+    name: string;
+    slug: string;
+    created_at: string;
+    member_count: number;
+    last_memory_at: string | null;
+    joined_at: string;
+  }>;
+  current_team: {
+    id: string;
+    name: string;
+    slug: string;
+  } | null;
+  stats: {
+    total_memories: number;
+    this_week: number;
+    team_members: number;
+    files_touched: number;
+  };
+  recent_memories: Array<{
+    id: string;
+    original_query: string;
+    goal: string | null;
+    status: string;
+    created_at: string;
+    files_touched: string[] | null;
+    tags: string[] | null;
+    profile: {
+      email: string;
+      full_name: string | null;
+      avatar_url: string | null;
+    } | null;
+  }>;
+  error?: string;
+  code?: string;
+}
+
+/**
+ * Fetch all dashboard data in a single RPC call
+ * Reduces ~12 sequential queries to 1
+ */
+export async function getDashboardData(): Promise<DashboardRpcResponse | null> {
+  const supabase = await createClient();
+
+  const { data, error } = await supabase.rpc('get_dashboard_data_v2');
+
+  if (error) {
+    console.error('Dashboard RPC error:', error);
+    return null;
+  }
+
+  // Handle auth error from RPC
+  if (data?.error) {
+    console.error('Dashboard RPC returned error:', data.error);
+    return null;
+  }
+
+  return data as DashboardRpcResponse;
+}

--- a/dashboard/src/lib/queries/index.ts
+++ b/dashboard/src/lib/queries/index.ts
@@ -28,3 +28,9 @@ export {
   isAuthenticated,
   type CurrentUser,
 } from './profiles';
+
+// Dashboard RPC (optimized single-query fetch)
+export {
+  getDashboardData,
+  type DashboardRpcResponse,
+} from './dashboard-rpc';

--- a/dashboard/src/lib/queries/profiles.ts
+++ b/dashboard/src/lib/queries/profiles.ts
@@ -1,3 +1,4 @@
+import { cache } from 'react';
 import { createClient } from '@/lib/supabase/server';
 import { getAuthUser } from '@/lib/auth';
 
@@ -12,7 +13,7 @@ export interface CurrentUser {
 /**
  * Get the current authenticated user's profile
  */
-export async function getCurrentUser(): Promise<CurrentUser | null> {
+export const getCurrentUser = cache(async (): Promise<CurrentUser | null> => {
   const user = await getAuthUser();
 
   if (!user) return null;
@@ -35,7 +36,7 @@ export async function getCurrentUser(): Promise<CurrentUser | null> {
   }
 
   return profile as CurrentUser;
-}
+});
 
 /**
  * Check if user is authenticated

--- a/dashboard/src/lib/queries/teams.ts
+++ b/dashboard/src/lib/queries/teams.ts
@@ -1,3 +1,4 @@
+import { cache } from 'react';
 import { createClient } from '@/lib/supabase/server';
 import { getAuthUser, verifyTeamMembership } from '@/lib/auth';
 import type { Team, TeamMember, TeamRole } from '@grov/shared';
@@ -41,7 +42,7 @@ interface TeamInvitationQueryResult {
 /**
  * Get all teams the current user is a member of
  */
-export async function getUserTeams(): Promise<TeamWithMemberCount[]> {
+export const getUserTeams = cache(async (): Promise<TeamWithMemberCount[]> => {
   const user = await getAuthUser();
 
   if (!user) return [];
@@ -78,7 +79,7 @@ export async function getUserTeams(): Promise<TeamWithMemberCount[]> {
     ...team,
     member_count: countMap.get(team.id) || 0,
   }));
-}
+});
 
 /**
  * Get team by ID (if user is a member)


### PR DESCRIPTION

## Description
- Add get_dashboard_data_v2 RPC to batch 12 queries into 1
- Add dashboard-rpc.ts client for type-safe RPC calls
- Add React cache() wrappers to teams.ts and profiles.ts
- Update dashboard page to use new RPC
## Related Issue
<!-- Link to the issue this PR addresses -->
Closes #26 

## Type of Change
<!-- Mark the relevant option with an [x] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional changes)

## Changes Made
<!-- List the specific changes -->
-
-
-

## Testing
<!-- Describe how you tested these changes -->
- [x] Tested locally
- [ ] Added/updated tests
- [ ] All tests passing

## Screenshots (if applicable)
<!-- Add screenshots for UI changes -->

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have updated the documentation accordingly
