### PR TITLE
Fix goal/title extraction producing garbage in memories

### DIFF
--- a/src/lib/llm-extractor.ts
+++ b/src/lib/llm-extractor.ts
@@ -297,7 +297,6 @@ export interface TaskAnalysis {
   task_type: 'information' | 'planning' | 'implementation';
   action: 'continue' | 'new_task' | 'subtask' | 'parallel_task' | 'task_complete' | 'subtask_complete';
   task_id: string;
-  current_goal: string;
   parent_task_id?: string;
   reasoning: string;
   step_reasoning?: string;  // Compressed reasoning for steps (if assistantResponse > 1000 chars)
@@ -395,7 +394,6 @@ Return a JSON object with these fields:
 - task_type: one of "information", "planning", or "implementation"
 - action: one of "continue", "task_complete", "new_task", or "subtask_complete"
 - task_id: existing session_id "${currentSession?.session_id || 'NEW'}" or "NEW" for new task
-- current_goal: the goal based on the latest user message
 - reasoning: brief explanation of why you made this decision${compressionInstruction}
 </output>
 
@@ -572,7 +570,7 @@ RESPONSE RULES:
       analysis.step_reasoning = assistantResponse.substring(0, 1000);
     }
 
-    debugLLM('analyzeTaskContext', `Result: task_type=${analysis.task_type}, action=${analysis.action}, goal="${analysis.current_goal?.substring(0, 50) || 'N/A'}" reasoning="${analysis.reasoning?.substring(0, 150) || 'none'}"`);
+    debugLLM('analyzeTaskContext', `Result: task_type=${analysis.task_type}, action=${analysis.action}, reasoning="${analysis.reasoning?.substring(0, 150) || 'none'}"`);
 
     return analysis;
   } catch (parseError) {
@@ -583,7 +581,6 @@ RESPONSE RULES:
       task_type: 'implementation',
       action: currentSession ? 'continue' : 'new_task',
       task_id: currentSession?.session_id || 'NEW',
-      current_goal: latestUserMessage.substring(0, 200),
       reasoning: 'Fallback due to parse error',
       step_reasoning: assistantResponse.substring(0, 1000),
     };

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -549,10 +549,22 @@ async function postProcessResponse(
     } else if (!activeSession) {
       // First request, create session without task analysis
       const newSessionId = randomUUID();
+
+      // Extract clean goal summary instead of using raw text
+      let goalSummary = latestUserMessage.substring(0, 500) || 'Task in progress';
+      if (isIntentExtractionAvailable() && latestUserMessage.length > 10) {
+        try {
+          const intentData = await extractIntent(latestUserMessage);
+          goalSummary = intentData.goal;
+        } catch {
+          // Keep fallback goalSummary
+        }
+      }
+
       activeSession = createSessionState({
         session_id: newSessionId,
         project_path: sessionInfo.projectPath,
-        original_goal: latestUserMessage.substring(0, 500) || 'Task in progress',
+        original_goal: goalSummary,
         task_type: 'main',
       });
       activeSessionId = newSessionId;
@@ -582,7 +594,6 @@ async function postProcessResponse(
         msg: 'Task analysis',
         action: taskAnalysis.action,
         task_type: taskAnalysis.task_type,
-        goal: taskAnalysis.current_goal?.substring(0, 50),
         reasoning: taskAnalysis.reasoning,
       });
 
@@ -591,7 +602,6 @@ async function postProcessResponse(
         sessionId: sessionInfo.sessionId,
         action: taskAnalysis.action,
         task_type: taskAnalysis.task_type,
-        goal: taskAnalysis.current_goal || '',
         reasoning: taskAnalysis.reasoning || '',
         userMessage: latestUserMessage.substring(0, 80),
         hasCurrentSession: !!sessionInfo.currentSession,
@@ -619,22 +629,11 @@ async function postProcessResponse(
             activeSessionId = sessionInfo.currentSession.session_id;
             activeSession = sessionInfo.currentSession;
 
-            // Update goal if Haiku detected a new instruction from user
-            // (same task/topic, but new specific instruction)
-            if (taskAnalysis.current_goal &&
-                taskAnalysis.current_goal !== activeSession.original_goal &&
-                latestUserMessage.length > 30) {
-              updateSessionState(activeSessionId, {
-                original_goal: taskAnalysis.current_goal,
-              });
-              activeSession.original_goal = taskAnalysis.current_goal;
-            }
             // TASK LOG: Continue existing session
             taskLog('ORCHESTRATION_CONTINUE', {
               sessionId: activeSessionId,
               source: 'current_session',
               goal: activeSession.original_goal,
-              goalUpdated: taskAnalysis.current_goal !== activeSession.original_goal,
             });
           } else if (sessionInfo.completedSession) {
             // Reactivate completed session (user wants to continue/add to it)
@@ -642,7 +641,6 @@ async function postProcessResponse(
             activeSession = sessionInfo.completedSession;
             updateSessionState(activeSessionId, {
               status: 'active',
-              original_goal: taskAnalysis.current_goal || activeSession.original_goal,
             });
             activeSession.status = 'active';
             activeSessions.set(activeSessionId, {
@@ -671,7 +669,7 @@ async function postProcessResponse(
 
           // Extract full intent for new task (goal, scope, constraints, keywords)
           let intentData = {
-            goal: taskAnalysis.current_goal,
+            goal: latestUserMessage.substring(0, 500),
             expected_scope: [] as string[],
             constraints: [] as string[],
             keywords: [] as string[],
@@ -763,7 +761,7 @@ async function postProcessResponse(
         case 'subtask': {
           // Extract intent for subtask
           let intentData = {
-            goal: taskAnalysis.current_goal,
+            goal: latestUserMessage.substring(0, 500),
             expected_scope: [] as string[],
             constraints: [] as string[],
             keywords: [] as string[],
@@ -815,7 +813,7 @@ async function postProcessResponse(
         case 'parallel_task': {
           // Extract intent for parallel task
           let intentData = {
-            goal: taskAnalysis.current_goal,
+            goal: latestUserMessage.substring(0, 500),
             expected_scope: [] as string[],
             constraints: [] as string[],
             keywords: [] as string[],
@@ -919,10 +917,22 @@ async function postProcessResponse(
             // Example: user asks clarification question, answer is provided in single turn
             try {
               const newSessionId = randomUUID();
+
+              // Extract clean goal summary instead of using raw text
+              let goalSummary = latestUserMessage.substring(0, 500);
+              if (isIntentExtractionAvailable() && latestUserMessage.length > 10) {
+                try {
+                  const intentData = await extractIntent(latestUserMessage);
+                  goalSummary = intentData.goal;
+                } catch {
+                  // Keep fallback goalSummary
+                }
+              }
+
               const instantSession = createSessionState({
                 session_id: newSessionId,
                 project_path: sessionInfo.projectPath,
-                original_goal: taskAnalysis.current_goal || latestUserMessage.substring(0, 500),
+                original_goal: goalSummary,
                 task_type: 'main',
               });
 
@@ -938,7 +948,7 @@ async function postProcessResponse(
               // TASK LOG: Instant complete (new task that finished in one turn)
               taskLog('ORCHESTRATION_TASK_COMPLETE', {
                 sessionId: newSessionId,
-                goal: taskAnalysis.current_goal || latestUserMessage.substring(0, 80),
+                goal: goalSummary,
                 source: 'instant_complete',
               });
             } catch (err) {


### PR DESCRIPTION
- Fix goal/title extraction producing garbage in memories
- Remove current_goal from analyzeTaskContext() - it was never designed for goal extraction
- extractIntent() is now the single source of truth for goals
- Goals are set once at session creation, no longer overwritten by noisy task analysis

## Description
- Problem: Memory titles were showing garbage like "You are now a prompt suggestion generator..." or raw user prompts instead of clean summaries
- Root cause: analyzeTaskContext() was outputting current_goal as a side-effect, but its noisy input (conversation history, tool calls, assistant responses) caused Haiku to extract garbage. This garbage then overwrote good goals from extractIntent().
- Solution: Removed current_goal from analyzeTaskContext() entirely. Goals now only come from extractIntent() which has focused input and produces clean summaries.
- Files changed: llm-extractor.ts, server.ts
- Testing: Verified new memories have clean, relevant titles that match their reasoning traces and decisions

## Related Issue
<!-- Link to the issue this PR addresses -->
Closes #

## Type of Change
<!-- Mark the relevant option with an [x] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)



## Testing
<!-- Describe how you tested these changes -->
- [x] Tested locally
- [] Added/updated tests
- [x] All tests passing

## Screenshots (if applicable)
<!-- Add screenshots for UI changes -->

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have updated the documentation accordingly
