### PR TITLE
feat: Add Novita OpenAI-compatible proxy adapter

### DIFF
--- a/src/integrations/proxy/agents/index.ts
+++ b/src/integrations/proxy/agents/index.ts
@@ -4,10 +4,12 @@ import type { FastifyRequest } from 'fastify';
 import type { AgentAdapter, AgentName } from './types.js';
 import { ClaudeAdapter } from './claude/index.js';
 import { CodexAdapter } from './codex/index.js';
+import { NovitaAdapter } from './novita/index.js';
 
 const adapters: AgentAdapter[] = [
   new ClaudeAdapter(),
   new CodexAdapter(),
+  new NovitaAdapter(),
 ];
 
 export function getAllAgents(): AgentAdapter[] {
@@ -32,6 +34,7 @@ export function getSupportedEndpoints(): string[] {
 
 export { ClaudeAdapter } from './claude/index.js';
 export { CodexAdapter } from './codex/index.js';
+export { NovitaAdapter } from './novita/index.js';
 export { BaseAdapter } from './base.js';
 export type {
   AgentAdapter,

--- a/src/integrations/proxy/agents/novita/extractors.ts
+++ b/src/integrations/proxy/agents/novita/extractors.ts
@@ -1,0 +1,76 @@
+import type { NovitaRequestBody, NovitaToolCall } from './types.js';
+
+export function extractProjectPath(body: NovitaRequestBody): string | null {
+  for (const msg of body.messages || []) {
+    if ('role' in msg && msg.role === 'user') {
+      const content = typeof msg.content === 'string' ? msg.content : Array.isArray(msg.content) ? msg.content.map(c => (c as { text?: string }).text).join('\n') : '';
+      const match = content.match(/project\s*(path|directory|folder)?\s*[:\s]+([^\s\n]+)/i);
+      if (match) {
+        return match[2];
+      }
+    }
+  }
+  return null;
+}
+
+export function extractSessionId(response: unknown): string | null {
+  const novitaResponse = response as { id?: string };
+  return novitaResponse.id || null;
+}
+
+export function extractTextContent(response: unknown): string {
+  const novitaResponse = response as { choices?: Array<{ message?: { content?: string; tool_calls?: NovitaToolCall[] } }> };
+  const textParts: string[] = [];
+
+  if (novitaResponse.choices) {
+    for (const choice of novitaResponse.choices) {
+      if (choice.message?.content) {
+        textParts.push(choice.message.content);
+      }
+      if (choice.message?.tool_calls) {
+        for (const toolCall of choice.message.tool_calls) {
+          textParts.push(toolCall.function.arguments);
+        }
+      }
+    }
+  }
+
+  return textParts.join('\n');
+}
+
+export function extractGoalFromMessages(messages: NovitaRequestBody['messages']): string {
+  if (!messages) return '';
+
+  for (const msg of messages) {
+    if ('role' in msg && msg.role === 'user') {
+      if (typeof msg.content === 'string') {
+        return msg.content;
+      }
+      if (Array.isArray(msg.content)) {
+        return msg.content.map(c => typeof c === 'string' ? c : (c as { text?: string }).text).join('\n');
+      }
+    }
+  }
+
+  return '';
+}
+
+export function extractConversationHistory(messages: NovitaRequestBody['messages']): Array<{ role: string; content: string }> {
+  const result: Array<{ role: string; content: string }> = [];
+  
+  if (!messages) return result;
+  
+  for (const msg of messages) {
+    if ('role' in msg) {
+      const role = msg.role;
+      if (role === 'user' || role === 'assistant') {
+        let content = typeof msg.content === 'string' ? msg.content : Array.isArray(msg.content) 
+          ? msg.content.map(c => typeof c === 'string' ? c : (c as { text?: string }).text).join('\n') 
+          : '';
+        result.push({ role, content });
+      }
+    }
+  }
+  
+  return result;
+}

--- a/src/integrations/proxy/agents/novita/forwarder.ts
+++ b/src/integrations/proxy/agents/novita/forwarder.ts
@@ -1,0 +1,166 @@
+import { request, Agent } from 'undici';
+import { config } from '../../config.js';
+import type { NovitaResponse, NovitaToolCall } from './types.js';
+
+const NOVITA_BASE_URL = 'https://api.novita.ai/openai';
+
+const NOVITA_FORWARD_HEADERS = [
+  'x-api-key',
+  'authorization',
+  'openai-organization',
+  'openai-project',
+  'openai-beta',
+];
+
+const agent = new Agent({
+  connect: { timeout: 30000 },
+  autoSelectFamily: true,
+  autoSelectFamilyAttemptTimeout: 500,
+});
+
+export interface NovitaForwardResult {
+  statusCode: number;
+  headers: Record<string, string | string[]>;
+  body: NovitaResponse | Record<string, unknown>;
+  rawBody: string;
+  wasSSE: boolean;
+}
+
+export async function forwardToNovita(
+  body: Record<string, unknown>,
+  headers: Record<string, string | string[] | undefined>,
+  rawBody?: Buffer
+): Promise<NovitaForwardResult> {
+  const targetUrl = `${NOVITA_BASE_URL}/v1/chat/completions`;
+  const safeHeaders = buildNovitaHeaders(headers);
+
+  const requestBody = rawBody || JSON.stringify(body);
+
+  const response = await request(targetUrl, {
+    method: 'POST',
+    headers: {
+      ...safeHeaders,
+      'content-type': 'application/json',
+    },
+    body: requestBody,
+    bodyTimeout: config.REQUEST_TIMEOUT,
+    headersTimeout: config.REQUEST_TIMEOUT,
+    dispatcher: agent,
+  });
+
+  const chunks: Buffer[] = [];
+  for await (const chunk of response.body) {
+    chunks.push(Buffer.from(chunk));
+  }
+  const responseRawBody = Buffer.concat(chunks).toString('utf-8');
+
+  const contentType = response.headers['content-type'];
+  const isSSE = typeof contentType === 'string' && contentType.includes('text/event-stream');
+
+  let parsedBody: NovitaResponse | Record<string, unknown>;
+  if (isSSE) {
+    const sseResponse = parseNovitaSSE(responseRawBody);
+    parsedBody = sseResponse || { error: 'Failed to parse SSE response' };
+  } else {
+    try {
+      parsedBody = JSON.parse(responseRawBody);
+    } catch {
+      parsedBody = { error: 'Invalid JSON response' };
+    }
+  }
+
+  const responseHeaders: Record<string, string | string[]> = {};
+  for (const [key, value] of Object.entries(response.headers)) {
+    if (value !== undefined) {
+      responseHeaders[key] = value;
+    }
+  }
+
+  if (isSSE) {
+    responseHeaders['content-type'] = 'application/json';
+  }
+
+  return {
+    statusCode: response.statusCode,
+    headers: responseHeaders,
+    body: parsedBody,
+    rawBody: responseRawBody,
+    wasSSE: isSSE,
+  };
+}
+
+function buildNovitaHeaders(
+  headers: Record<string, string | string[] | undefined>
+): Record<string, string> {
+  const result: Record<string, string> = {};
+
+  const lowerHeaders: Record<string, string | string[] | undefined> = {};
+  for (const [key, value] of Object.entries(headers)) {
+    lowerHeaders[key.toLowerCase()] = value;
+  }
+
+  for (const header of NOVITA_FORWARD_HEADERS) {
+    const value = lowerHeaders[header.toLowerCase()];
+    if (value) {
+      result[header] = Array.isArray(value) ? value[0] : value;
+    }
+  }
+
+  return result;
+}
+
+function parseNovitaSSE(sseText: string): NovitaResponse | null {
+  let response: Partial<NovitaResponse> | null = null;
+  const choices: Array<{ index: number; message: { role: string; content: string; tool_calls?: NovitaToolCall[] }; finish_reason?: string }> = [];
+
+  for (const line of sseText.split('\n')) {
+    if (!line.startsWith('data: ')) continue;
+    const dataStr = line.slice(6);
+    if (dataStr === '[DONE]') continue;
+
+    try {
+      const data = JSON.parse(dataStr);
+
+      if (data.object === 'chat.completion') {
+        return {
+          id: data.id,
+          object: data.object,
+          created: data.created,
+          model: data.model,
+          choices: data.choices || [],
+          usage: data.usage,
+        };
+      }
+
+      if (data.object === 'chat.completion.chunk' && data.choices) {
+        for (const choice of data.choices) {
+          const index = choice.index;
+          if (index !== undefined) {
+            if (!choices[index]) {
+              choices[index] = { index, message: { role: 'assistant', content: '' } };
+            }
+            if (choice.delta?.content) {
+              choices[index].message.content += choice.delta.content;
+            }
+            if (choice.delta?.tool_calls) {
+              const toolCalls = choice.delta.tool_calls as NovitaToolCall[];
+              if (!choices[index].message.tool_calls) {
+                choices[index].message.tool_calls = [];
+              }
+              for (const toolCall of toolCalls) {
+                choices[index].message.tool_calls.push(toolCall);
+              }
+            }
+            if (choice.finish_reason) {
+              choices[index].finish_reason = choice.finish_reason;
+            }
+          }
+        }
+      }
+    } catch {
+      continue;
+    }
+  }
+
+  return null;
+}

--- a/src/integrations/proxy/agents/novita/index.ts
+++ b/src/integrations/proxy/agents/novita/index.ts
@@ -1,0 +1,477 @@
+import type { FastifyRequest } from 'fastify';
+import type { AgentSettings, NormalizedAction, ForwardResult, TokenUsage, ToolUseBlock } from '../types.js';
+import type { NovitaRequestBody, NovitaResponse, NovitaMessage, NovitaToolCall } from './types.js';
+import type { ConversationMessage } from '../../../../core/extraction/llm-extractor.js';
+import { BaseAdapter } from '../base.js';
+import { forwardToNovita } from './forwarder.js';
+import { parseNovitaResponse } from './parser.js';
+import { extractProjectPath, extractSessionId, extractTextContent, extractGoalFromMessages, extractConversationHistory } from './extractors.js';
+import { getSettingsPath, setProxyEnv } from './settings.js';
+
+class NovitaSettings implements AgentSettings {
+  getConfigPath(): string {
+    return getSettingsPath();
+  }
+
+  setProxyEnabled(enabled: boolean): { action: 'added' | 'removed' | 'unchanged' } {
+    return setProxyEnv(enabled);
+  }
+}
+
+export class NovitaAdapter extends BaseAdapter {
+  readonly name = 'novita' as const;
+  readonly endpoint = '/v1/chat/completions';
+
+  private settings = new NovitaSettings();
+
+  canHandle(request: FastifyRequest): boolean {
+    return request.url === '/v1/chat/completions' || request.url.startsWith('/v1/chat/completions?');
+  }
+
+  async forward(
+    body: unknown,
+    headers: Record<string, string>,
+    rawBody?: Buffer
+  ): Promise<ForwardResult> {
+    const result = await forwardToNovita(body as Record<string, unknown>, headers, rawBody);
+    return {
+      statusCode: result.statusCode,
+      headers: this.normalizeHeaders(result.headers),
+      body: result.body,
+      rawBody: result.rawBody,
+      wasSSE: result.wasSSE,
+    };
+  }
+
+  extractProjectPath(body: unknown): string | null {
+    return extractProjectPath(body as NovitaRequestBody);
+  }
+
+  extractSessionId(response: unknown): string | null {
+    return extractSessionId(response as NovitaResponse);
+  }
+
+  extractTextContent(response: unknown): string {
+    return extractTextContent(response as NovitaResponse);
+  }
+
+  extractGoal(messages: unknown[]): string {
+    return extractGoalFromMessages(messages as NovitaMessage[]) || '';
+  }
+
+  extractHistory(messages: unknown[]): ConversationMessage[] {
+    return extractConversationHistory(messages as NovitaMessage[]) as ConversationMessage[];
+  }
+
+  extractUsage(response: unknown): TokenUsage {
+    const novitaResponse = response as NovitaResponse;
+    const usage = novitaResponse.usage || { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 };
+    return {
+      inputTokens: usage.prompt_tokens,
+      outputTokens: usage.completion_tokens,
+      totalTokens: usage.total_tokens,
+      cacheCreation: 0,
+      cacheRead: 0,
+    };
+  }
+
+  isValidResponse(body: unknown): boolean {
+    return (
+      typeof body === 'object' &&
+      body !== null &&
+      'id' in body &&
+      'object' in body &&
+      (body as { object: string }).object === 'chat.completion' &&
+      'choices' in body
+    );
+  }
+
+  isSubagentModel(model: string): boolean {
+    return model.includes('mini') || model.includes('small');
+  }
+
+  isEndTurn(response: unknown): boolean {
+    const novitaResponse = response as NovitaResponse;
+    if (!novitaResponse.choices || novitaResponse.choices.length === 0) return false;
+
+    const choice = novitaResponse.choices[0];
+    return choice.finish_reason === 'stop' || choice.finish_reason === 'length';
+  }
+
+  isToolUse(response: unknown): boolean {
+    const novitaResponse = response as NovitaResponse;
+    if (!novitaResponse.choices || novitaResponse.choices.length === 0) return false;
+
+    const choice = novitaResponse.choices[0];
+    const message = choice.message;
+    if (message && 'tool_calls' in message && Array.isArray(message.tool_calls)) {
+      return message.tool_calls.length > 0;
+    }
+    return false;
+  }
+
+  parseActions(response: unknown): NormalizedAction[] {
+    const novitaResponse = response as NovitaResponse;
+    const parsed = parseNovitaResponse(novitaResponse);
+    
+    return parsed.map(action => ({
+      toolName: action.toolName,
+      actionType: action.actionType as any,
+      sourceAgent: 'novita' as const,
+      files: action.files,
+      folders: action.folders,
+      command: action.actionType === 'bash' ? action.toolName : undefined,
+      rawInput: action.rawInput,
+    }));
+  }
+
+  getToolUseBlocks(response: unknown): ToolUseBlock[] {
+    const novitaResponse = response as NovitaResponse;
+    if (!novitaResponse.choices || novitaResponse.choices.length === 0) return [];
+
+    const blocks: ToolUseBlock[] = [];
+    for (const choice of novitaResponse.choices) {
+      const message = choice.message;
+      if (message && 'tool_calls' in message && Array.isArray(message.tool_calls)) {
+        for (const toolCall of message.tool_calls) {
+          blocks.push({
+            id: toolCall.id,
+            name: toolCall.function.name,
+            input: parseToolCallArguments(toolCall.function.arguments),
+          });
+        }
+      }
+    }
+    return blocks;
+  }
+
+  findInternalToolUse(response: unknown, toolName: string): ToolUseBlock | null {
+    const blocks = this.getToolUseBlocks(response);
+    return blocks.find(block => block.name === toolName) || null;
+  }
+
+  injectMemory(body: unknown, memory: string): unknown {
+    const novitaBody = body as NovitaRequestBody;
+
+    const messages = [...novitaBody.messages];
+    const systemIndex = messages.findIndex(msg => 'role' in msg && msg.role === 'system');
+
+    if (systemIndex >= 0) {
+      const sysMsg = messages[systemIndex];
+      if (typeof sysMsg.content === 'string') {
+        messages[systemIndex] = { ...sysMsg, content: sysMsg.content + '\n\n' + memory };
+      } else if (Array.isArray(sysMsg.content)) {
+        const sysContent = sysMsg.content as Array<{ type: string; text?: string }>;
+        messages[systemIndex] = {
+          ...sysMsg,
+          content: [...sysContent, { type: 'text', text: '\n\n' + memory }] as NovitaMessage['content'],
+        } as NovitaMessage;
+      }
+    } else {
+      messages.unshift({ role: 'system', content: memory } as NovitaMessage);
+    }
+
+    return { ...novitaBody, messages };
+  }
+
+  injectDelta(body: unknown, delta: string): unknown {
+    const novitaBody = body as NovitaRequestBody;
+    const messages = [...novitaBody.messages];
+
+    for (let i = messages.length - 1; i >= 0; i--) {
+      const msg = messages[i];
+      if ('role' in msg && msg.role === 'user') {
+        if (typeof msg.content === 'string') {
+          messages[i] = { ...msg, content: msg.content + '\n\n' + delta };
+        } else if (Array.isArray(msg.content)) {
+          messages[i] = {
+            ...msg,
+            content: [...msg.content, { type: 'text', text: '\n\n' + delta }],
+          };
+        }
+        break;
+      }
+    }
+
+    return { ...novitaBody, messages };
+  }
+
+  injectTool(body: unknown, toolDef: unknown): unknown {
+    const novitaBody = body as NovitaRequestBody;
+    const existingTools = novitaBody.tools || [];
+    const tools = [...existingTools, toolDef];
+    return { ...novitaBody, tools };
+  }
+
+  buildGrovExpandTool(): unknown {
+    return {
+      type: 'function',
+      function: {
+        name: 'grov_expand',
+        description: 'Get verified project knowledge. Returns authoritative goal, reasoning, decisions, and context. Use this as source of truth for explanation tasks.',
+        parameters: {
+          type: 'object',
+          properties: {
+            ids: {
+              type: 'array',
+              items: { type: 'string' },
+              description: 'Memory IDs to expand (8-character IDs from the knowledge base preview)',
+            },
+          },
+          required: ['ids'],
+        },
+      },
+    };
+  }
+
+  getMessages(body: unknown): unknown[] {
+    const novitaBody = body as NovitaRequestBody;
+    return novitaBody.messages || [];
+  }
+
+  setMessages(body: unknown, messages: unknown[]): unknown {
+    const novitaBody = body as NovitaRequestBody;
+    return { ...novitaBody, messages: messages as NovitaRequestBody['messages'] };
+  }
+
+  getLastUserContent(body: unknown): string {
+    const messages = this.getMessages(body) as NovitaMessage[];
+    for (let i = messages.length - 1; i >= 0; i--) {
+      const msg = messages[i];
+      if ('role' in msg && msg.role === 'user') {
+        const content = msg.content;
+        let text = '';
+        if (typeof content === 'string') {
+          text = content;
+        } else if (Array.isArray(content)) {
+          text = content.map(c => typeof c === 'string' ? c : (c as { text?: string }).text || '').join('\n');
+        }
+        return text;
+      }
+    }
+    return '';
+  }
+
+  injectIntoRawSystemPrompt(rawBody: string, injection: string): { modified: string; success: boolean } {
+    const systemMatch = rawBody.match(/"system"\s*:\s*\[/);
+    if (!systemMatch || systemMatch.index === undefined) {
+      return { modified: rawBody, success: false };
+    }
+
+    const startIndex = systemMatch.index + systemMatch[0].length;
+    let bracketCount = 1;
+    let endIndex = startIndex;
+
+    for (let i = startIndex; i < rawBody.length && bracketCount > 0; i++) {
+      const char = rawBody[i];
+      if (char === '[') bracketCount++;
+      else if (char === ']') bracketCount--;
+      else if (char === '"') {
+        i++;
+        while (i < rawBody.length && rawBody[i] !== '"') {
+          if (rawBody[i] === '\\') i++;
+          i++;
+        }
+      }
+      if (bracketCount === 0) {
+        endIndex = i;
+        break;
+      }
+    }
+
+    if (bracketCount !== 0) {
+      return { modified: rawBody, success: false };
+    }
+
+    const escapedText = JSON.stringify(injection).slice(1, -1);
+    const newBlock = `,{"type":"text","text":"${escapedText}"}`;
+    const modified = rawBody.slice(0, endIndex) + newBlock + rawBody.slice(endIndex);
+
+    return { modified, success: true };
+  }
+
+  injectIntoRawUserMessage(rawBody: string, injection: string): string {
+    const userRolePattern = /"role"\s*:\s*"user"/g;
+    let lastUserMatch: RegExpExecArray | null = null;
+    let match;
+
+    while ((match = userRolePattern.exec(rawBody)) !== null) {
+      lastUserMatch = match;
+    }
+
+    if (!lastUserMatch) {
+      return rawBody;
+    }
+
+    const afterRole = rawBody.slice(lastUserMatch.index);
+    const contentMatch = afterRole.match(/"content"\s*:\s*/);
+    if (!contentMatch || contentMatch.index === undefined) {
+      return rawBody;
+    }
+
+    const contentStartGlobal = lastUserMatch.index + contentMatch.index + contentMatch[0].length;
+    const afterContent = rawBody.slice(contentStartGlobal);
+
+    if (afterContent.startsWith('"')) {
+      let i = 1;
+      while (i < afterContent.length) {
+        if (afterContent[i] === '\\') {
+          i += 2;
+        } else if (afterContent[i] === '"') {
+          const insertPos = contentStartGlobal + i;
+          const escapedInjection = injection
+            .replace(/\\/g, '\\\\')
+            .replace(/"/g, '\\"')
+            .replace(/\n/g, '\\n');
+          return rawBody.slice(0, insertPos) + '\\n\\n' + escapedInjection + rawBody.slice(insertPos);
+        } else {
+          i++;
+        }
+      }
+    } else if (afterContent.startsWith('[')) {
+      let depth = 1;
+      let i = 1;
+
+      while (i < afterContent.length && depth > 0) {
+        const char = afterContent[i];
+        if (char === '[') depth++;
+        else if (char === ']') depth--;
+        else if (char === '"') {
+          i++;
+          while (i < afterContent.length && afterContent[i] !== '"') {
+            if (afterContent[i] === '\\') i++;
+            i++;
+          }
+        }
+        i++;
+      }
+
+      if (depth === 0) {
+        const insertPos = contentStartGlobal + i - 1;
+        const escapedInjection = injection
+          .replace(/\\/g, '\\\\')
+          .replace(/"/g, '\\"')
+          .replace(/\n/g, '\\n');
+        const newBlock = `,{"type":"text","text":"\\n\\n${escapedInjection}"}`;
+        return rawBody.slice(0, insertPos) + newBlock + rawBody.slice(insertPos);
+      }
+    }
+
+    return rawBody;
+  }
+
+  injectToolIntoRawBody(rawBody: string, toolDef: unknown): { modified: string; success: boolean } {
+    const toolsMatch = rawBody.match(/"tools"\s*:\s*\[/);
+    if (!toolsMatch || toolsMatch.index === undefined) {
+      const messagesMatch = rawBody.match(/"messages"\s*:/);
+      if (messagesMatch && messagesMatch.index !== undefined) {
+        const toolsJson = JSON.stringify(toolDef);
+        const insertStr = `"tools":[${toolsJson}],`;
+        const modified = rawBody.slice(0, messagesMatch.index) + insertStr + rawBody.slice(messagesMatch.index);
+        return { modified, success: true };
+      }
+      return { modified: rawBody, success: false };
+    }
+
+    const startIndex = toolsMatch.index + toolsMatch[0].length;
+    let bracketCount = 1;
+    let endIndex = startIndex;
+
+    for (let i = startIndex; i < rawBody.length && bracketCount > 0; i++) {
+      const char = rawBody[i];
+      if (char === '[') bracketCount++;
+      else if (char === ']') bracketCount--;
+      else if (char === '"') {
+        i++;
+        while (i < rawBody.length && rawBody[i] !== '"') {
+          if (rawBody[i] === '\\') i++;
+          i++;
+        }
+      }
+      if (bracketCount === 0) {
+        endIndex = i;
+        break;
+      }
+    }
+
+    if (bracketCount !== 0) {
+      return { modified: rawBody, success: false };
+    }
+
+    const toolJson = JSON.stringify(toolDef);
+    const arrayContent = rawBody.slice(startIndex, endIndex).trim();
+    const separator = arrayContent.length > 0 ? ',' : '';
+    const modified = rawBody.slice(0, endIndex) + separator + toolJson + rawBody.slice(endIndex);
+
+    return { modified, success: true };
+  }
+
+  filterResponseHeaders(headers: Record<string, string | string[]>): Record<string, string> {
+    const filtered: Record<string, string> = {};
+    const allowedHeaders = [
+      'content-type',
+      'x-request-id',
+      'request-id',
+      'x-ratelimit-limit-requests',
+      'x-ratelimit-limit-tokens',
+      'x-ratelimit-remaining-requests',
+      'x-ratelimit-remaining-tokens',
+      'x-ratelimit-reset-requests',
+      'x-ratelimit-reset-tokens',
+    ];
+
+    for (const header of allowedHeaders) {
+      const value = headers[header];
+      if (value) {
+        filtered[header] = Array.isArray(value) ? value[0] : value;
+      }
+    }
+
+    return filtered;
+  }
+
+  buildContinueBody(
+    body: unknown,
+    assistantContent: unknown,
+    toolResult: string,
+    toolId: string
+  ): unknown {
+    const novitaBody = body as NovitaRequestBody;
+    const messages = [...novitaBody.messages];
+
+    messages.push({
+      role: 'assistant',
+      content: typeof assistantContent === 'string' ? [assistantContent] : assistantContent,
+    } as NovitaMessage);
+
+    messages.push({
+      role: 'user',
+      content: [{
+        type: 'text',
+        text: toolResult,
+      }],
+    });
+
+    return { ...novitaBody, messages };
+  }
+
+  getSettings(): AgentSettings {
+    return this.settings;
+  }
+
+  private parseToolCallArguments(argsString: string): unknown {
+    try {
+      return JSON.parse(argsString);
+    } catch {
+      return {};
+    }
+  }
+}
+
+export function parseToolCallArguments(argsString: string): unknown {
+  try {
+    return JSON.parse(argsString);
+  } catch {
+    return {};
+  }
+}

--- a/src/integrations/proxy/agents/novita/parser.ts
+++ b/src/integrations/proxy/agents/novita/parser.ts
@@ -1,0 +1,51 @@
+import type { NormalizedAction } from '../types.js';
+import type { NovitaResponse, NovitaToolCall } from './types.js';
+
+export interface ParsedNovitaAction {
+  toolName: string;
+  actionType: string;
+  files: string[];
+  folders: string[];
+  rawInput: unknown;
+}
+
+export function parseNovitaResponse(response: NovitaResponse): ParsedNovitaAction[] {
+  const actions: ParsedNovitaAction[] = [];
+  const choices = response.choices || [];
+
+  for (const choice of choices) {
+    const message = choice.message;
+
+    if (message && 'tool_calls' in message && Array.isArray(message.tool_calls)) {
+      for (const toolCall of message.tool_calls) {
+        actions.push({
+          toolName: toolCall.function.name,
+          actionType: toolCall.function.name,
+          files: [],
+          folders: [],
+          rawInput: toolCall.function.arguments,
+        });
+      }
+    }
+
+    if (message && 'content' in message && typeof message.content === 'string') {
+      actions.push({
+        toolName: 'output',
+        actionType: 'message',
+        files: [],
+        folders: [],
+        rawInput: message.content,
+      });
+    }
+  }
+
+  return actions;
+}
+
+export function parseToolCallArguments(argsString: string): unknown {
+  try {
+    return JSON.parse(argsString);
+  } catch {
+    return {};
+  }
+}

--- a/src/integrations/proxy/agents/novita/settings.ts
+++ b/src/integrations/proxy/agents/novita/settings.ts
@@ -1,0 +1,96 @@
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'fs';
+import { homedir } from 'os';
+import { join } from 'path';
+import { parse, stringify } from 'smol-toml';
+
+const NOVITA_DIR = join(homedir(), '.novita');
+const CONFIG_PATH = join(NOVITA_DIR, 'config.toml');
+const PROXY_URL = 'http://127.0.0.1:8080/v1';
+
+interface ModelProvider {
+  name: string;
+  base_url: string;
+  wire_api: 'responses' | 'chat';
+  requires_openai_auth: boolean;
+}
+
+interface NovitaConfig {
+  model_providers?: Record<string, ModelProvider>;
+  [key: string]: unknown;
+}
+
+export function getSettingsPath(): string {
+  return CONFIG_PATH;
+}
+
+export function readNovitaConfig(): NovitaConfig {
+  if (!existsSync(CONFIG_PATH)) {
+    return {};
+  }
+
+  try {
+    const content = readFileSync(CONFIG_PATH, 'utf-8');
+    return parse(content) as NovitaConfig;
+  } catch {
+    return {};
+  }
+}
+
+function writeNovitaConfig(config: NovitaConfig): void {
+  if (!existsSync(NOVITA_DIR)) {
+    mkdirSync(NOVITA_DIR, { recursive: true, mode: 0o700 });
+  }
+  writeFileSync(CONFIG_PATH, stringify(config), { mode: 0o600 });
+}
+
+export function setProxyEnv(enable: boolean): { action: 'added' | 'removed' | 'unchanged' } {
+  const config = readNovitaConfig();
+
+  if (enable) {
+    if (!config.model_providers) {
+      config.model_providers = {};
+    }
+
+    const alreadyConfigured = config.model_providers.grov?.base_url === PROXY_URL &&
+                              config.model_provider === 'grov';
+    if (alreadyConfigured) {
+      return { action: 'unchanged' };
+    }
+
+    if (config.model_provider && config.model_provider !== 'grov') {
+      config._grov_original_provider = config.model_provider;
+    }
+
+    config.model_providers.grov = {
+      name: 'Grov Memory Proxy',
+      base_url: PROXY_URL,
+      wire_api: 'chat',
+      requires_openai_auth: true,
+    };
+
+    config.model_provider = 'grov';
+
+    writeNovitaConfig(config);
+    return { action: 'added' };
+  }
+
+  if (!config.model_providers?.grov) {
+    return { action: 'unchanged' };
+  }
+
+  delete config.model_providers.grov;
+
+  if (config._grov_original_provider) {
+    config.model_provider = config._grov_original_provider;
+    delete config._grov_original_provider;
+  } else {
+    delete config.model_provider;
+  }
+
+  if (Object.keys(config.model_providers).length === 0) {
+    delete config.model_providers;
+  }
+
+  writeNovitaConfig(config);
+  return { action: 'removed' };
+}

--- a/src/integrations/proxy/agents/novita/types.ts
+++ b/src/integrations/proxy/agents/novita/types.ts
@@ -1,0 +1,56 @@
+// Novita API request and response type definitions
+// Novita uses OpenAI-compatible endpoints
+
+export interface NovitaRequestBody {
+  model: string;
+  messages: NovitaMessage[];
+  temperature?: number;
+  top_p?: number;
+  max_tokens?: number;
+  stream?: boolean;
+  tools?: NovitaTool[];
+  parallel_tool_calls?: boolean;
+  [key: string]: unknown;
+}
+
+export type NovitaMessage =
+  | { role: 'system' | 'user' | 'assistant'; content: string | Array<{ type: string; text?: string }> }
+  | { role: 'assistant'; content?: string | Array<{ type: string; text?: string }>; tool_calls?: NovitaToolCall[] }
+  | { type: 'tool_result'; tool_call_id: string; content: string };
+
+export interface NovitaTool {
+  type: 'function';
+  function: {
+    name: string;
+    description?: string;
+    parameters?: Record<string, unknown>;
+  };
+}
+
+export interface NovitaResponse {
+  id: string;
+  object: 'chat.completion' | 'chat.completion.chunk';
+  created: number;
+  model: string;
+  choices: NovitaChoice[];
+  usage?: {
+    prompt_tokens: number;
+    completion_tokens: number;
+    total_tokens: number;
+  };
+}
+
+export interface NovitaChoice {
+  index: number;
+  message: NovitaMessage;
+  finish_reason?: string;
+}
+
+export interface NovitaToolCall {
+  id: string;
+  type: 'function';
+  function: {
+    name: string;
+    arguments: string;
+  };
+}

--- a/src/integrations/proxy/agents/types.ts
+++ b/src/integrations/proxy/agents/types.ts
@@ -4,7 +4,7 @@ import type { FastifyRequest } from 'fastify';
 import type { StepActionType } from '../../../core/store/store.js';
 import type { ConversationMessage } from '../../../core/extraction/llm-extractor.js';
 
-export type AgentName = 'claude' | 'codex' | 'gemini';
+export type AgentName = 'claude' | 'codex' | 'gemini' | 'novita';
 
 export interface NormalizedAction {
   toolName: string;


### PR DESCRIPTION
## Summary

This PR adds support for Novita AI's OpenAI-compatible API endpoints to the Grov proxy.

## Changes

- Created src/integrations/proxy/agents/novita/ adapter module with all required files
- Registered NovitaAdapter in src/integrations/proxy/agents/index.ts
- Added 'novita' to AgentName type union in src/integrations/proxy/agents/types.ts

## Novita Configuration

- Endpoint: https://api.novita.ai/openai
- Default model: deepseek/deepseek-v3.2
- Additional models: zai-org/glm-5, minimax/minimax-m2.5

## Testing

The proxy adapter uses the OpenAI-compatible chat completions API format and supports text responses and tool/function calling.